### PR TITLE
Fix package name in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Use it the same as a normal markdown-it plugin:
 
 ```ts
 import MarkdownIt from 'markdown-it'
-import taskLists from '@codimd/markdown-it-task-lists'
+import taskLists from '@hedgedoc/markdown-it-task-lists'
 
 const parser = new MarkdownIt().use(taskLists)
 


### PR DESCRIPTION
Change the package name in the readme to `@hedgedoc/markdown-it-task-lists`.